### PR TITLE
Update the install link to point to the new docs

### DIFF
--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ With it, you can simulate many astrophysical systems.
 
 ### Getting Started
 
-The easiest way to use AMUSE is to install it with pip - see [installation](https://amuse.readthedocs.io/en/latest/install/howto-install-AMUSE.html).
+The easiest way to use AMUSE is to install it with pip - see [installation](https://amuse.readthedocs.io/en/latest/install/index.html).
 1. Install Python and other prerequisites, such as a compiler and MPI.
 2. (Optional) Create a virtual environment.
 3. Install AMUSE via pip.


### PR DESCRIPTION
With the new build system the documentation has been rewritten and reorganised, but we're still pointing to the old file (which is still there for some reason, I think I was afraid to delete it lest there be something useful in it). This points the link to the new installation instructions.