### PR TITLE
Update main page links and events

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ aux_links:
     "Documentation":
         - "https://amuse.readthedocs.io/en/latest/"
     "Installation":
-        - "https://amuse.readthedocs.io/en/latest/install/howto-install-AMUSE.html"
+        - "https://amuse.readthedocs.io/en/latest/install/index.html"
     "Wiki for sysadmins":
         - "https://github.com/amusecode/amuse/wiki"
     "FAQ":

--- a/community.md
+++ b/community.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Events and meetings
+title: Community
 nav_order: 3
-permalink: /events
+permalink: /community
 ---
 
 ## Online user meetings
@@ -13,7 +13,9 @@ us on [Jitsi](https://meet.jit.si/AMUSECommunityMeeting)!
 The user meetings are open to all AMUSE users, from beginners to experts.
 They are an excellent opportunity to ask us anything you wanted to know about AMUSE, from installation issues to advanced bridging methods.
 
-These meetings and other AMUSE related events are announced on Github: [https://github.com/amusecode/amuse/discussions/categories/events](https://github.com/amusecode/amuse/discussions/categories/events)
+## Slack
+
+[Join the AMUSE Slack](https://join.slack.com/t/amusecode/shared_invite/zt-3yacr6o12-ni0gXJg1jnjzmYV0b8yaVg) to connect to the community and the developers, ask for help, and be notified of user meetings.
 
 ## In-person meetings
 

--- a/events.md
+++ b/events.md
@@ -7,7 +7,9 @@ permalink: /events
 
 ## Online user meetings
 
-We organise biweekly user meetings, alternating between Friday afternoon and Friday mornings (European time).
+We organise biweekly user meetings on Friday afternoon 15:00 (3 PM) European time. Join
+us on [Jitsi](https://meet.jit.si/AMUSECommunityMeeting)!
+
 The user meetings are open to all AMUSE users, from beginners to experts.
 They are an excellent opportunity to ask us anything you wanted to know about AMUSE, from installation issues to advanced bridging methods.
 
@@ -19,6 +21,9 @@ We (irregularly) organise in-person meetings, either in the form of a workshop o
 These are organised at varying levels, with aims of teaching how to use AMUSE, contributing to AMUSE or usually a combination.
 
 ### Recent meetings:
+
+- [March 2026](https://indico.strw.leidenuniv.nl/event/5/overview): AMUSE Spring School 2026, Heidelberg, Germany
 - [April 2024](http://amusecode.org/workshopnyc): MODEST-24a at the AMNH in New York, USA
 - June 2022: AMUSE school at University of Geneva, Switzerland
 - December 2019: AMUSE school at Strasbourg University, France
+

--- a/index.md
+++ b/index.md
@@ -29,7 +29,7 @@ are appreciated, the source is in the github repository [tree](https://github.co
 ### Examples
 
 AMUSE comes with many examples, which you can find in the ["examples" directory on github](https://github.com/amusecode/amuse/tree/main/src/amuse/examples).
-The "textbook" examples are described in the [AMUSE book](https://iopscience.iop.org/book/978-0-7503-1320-9).
+The "textbook" examples are described in the [AMUSE book](https://iopscience.iop.org/book/mono/978-0-7503-5331-1).
 If you need help, don't hesitate to contact us (preferably by [creating an issue on github](https://github.com/amusecode/amuse/issues/new?assignees=&labels=question&template=question.md&title=)).
 
 ### Get involved

--- a/index.md
+++ b/index.md
@@ -11,11 +11,13 @@ With it, you can simulate many astrophysical systems.
 
 ### Getting Started
 
-The easiest way to use AMUSE is to install it with pip - see [installation](https://amuse.readthedocs.io/en/latest/install/index.html).
-1. Install Python and other prerequisites, such as a compiler and MPI.
-2. (Optional) Create a virtual environment.
-3. Install AMUSE via pip.
-4. Done! Try some of the examples if you like.
+The easiest way to use AMUSE is to install it with conda - see [installation](https://amuse.readthedocs.io/en/latest/install/index.html).
+
+1. Install conda, preferably using miniforge
+2. Create a conda environment
+3. Download the AMUSE source code
+4. Use ./setup to install AMUSE
+5. Done! Try some of the examples if you like.
 
 We also encourage you to register to the AMUSE announcements list at [https://groups.google.com/g/amusecode/about](https://groups.google.com/g/amusecode/about).
 

--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ are appreciated, the source is in the github repository [tree](https://github.co
 
 ### Examples
 
-AMUSE comes with many examples, which you can find in the ["examples" directory on github](https://github.com/amusecode/amuse/tree/master/examples).
+AMUSE comes with many examples, which you can find in the ["examples" directory on github](https://github.com/amusecode/amuse/tree/main/src/amuse/examples).
 The "textbook" examples are described in the [AMUSE book](https://iopscience.iop.org/book/978-0-7503-1320-9).
 If you need help, don't hesitate to contact us (preferably by [creating an issue on github](https://github.com/amusecode/amuse/issues/new?assignees=&labels=question&template=question.md&title=)).
 


### PR DESCRIPTION
This:
- Fixes the "Installation" link at the top of the main page
- Updates the installation summary in the body text
- Fixes the link to the examples on GitHub
- Updates the book link to the second edition
- Adds the community meeting (including a direct link to Jitsi) to the events page
- Adds the Heidelberg meeting to the events page

I'm thinking we should also add a public invite link to the AMUSE Slack to the events page, and maybe rename it "Community"? Any objections to that?